### PR TITLE
BODA-14 feat: 로그인 및 추가 정보 입력 기능 구현

### DIFF
--- a/src/main/java/com/example/boda_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/boda_server/domain/auth/controller/AuthController.java
@@ -1,26 +1,24 @@
 package com.example.boda_server.domain.auth.controller;
 
 import com.example.boda_server.domain.auth.service.AuthService;
-import com.example.boda_server.domain.user.dto.UserPartialDto;
-import com.example.boda_server.domain.user.entity.User;
+import com.example.boda_server.domain.user.dto.response.UserResponse;
+import com.example.boda_server.domain.user.dto.request.UserPartialRequest;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("/api/v1")
+@RequiredArgsConstructor
 public class AuthController {
 
-    @Autowired
-    private AuthService authService;
+    private final AuthService authService;
 
     @PostMapping("/register")
-    public ResponseEntity<User> register(HttpServletRequest http, @RequestBody UserPartialDto userPartialDto){
-        User created= authService.register(http, userPartialDto);
-
-        return ResponseEntity.status(HttpStatus.OK).body(created);
+    public ResponseEntity<UserResponse> register(HttpServletRequest http, @RequestBody UserPartialRequest userPartialRequest){
+        UserResponse created = authService.register(http, userPartialRequest);
+        return ResponseEntity.ok().body(created);
     }
 }

--- a/src/main/java/com/example/boda_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/boda_server/domain/auth/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.example.boda_server.domain.auth.controller;
+
+import com.example.boda_server.domain.auth.service.AuthService;
+import com.example.boda_server.domain.user.dto.UserPartialDto;
+import com.example.boda_server.domain.user.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/api/v1")
+public class AuthController {
+
+    @Autowired
+    private AuthService authService;
+
+    @PostMapping("/register")
+    public ResponseEntity<User> register(HttpServletRequest http, @RequestBody UserPartialDto userPartialDto){
+        User created= authService.register(http, userPartialDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(created);
+    }
+}

--- a/src/main/java/com/example/boda_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/boda_server/domain/auth/controller/AuthController.java
@@ -8,9 +8,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/api/v1")
+@RestController
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/com/example/boda_server/domain/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/example/boda_server/domain/auth/dto/CustomOAuth2User.java
@@ -1,0 +1,73 @@
+package com.example.boda_server.domain.auth.dto;
+
+import com.example.boda_server.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User, UserDetails {
+    private final User user;
+    private final Map<String, Object> attributes;
+    private final String attributeKey;
+
+    @Builder
+    public CustomOAuth2User(User user, Map<String, Object> attributes, String attributeKey) {
+        this.user = user;
+        this.attributes = attributes;
+        this.attributeKey = attributeKey;
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(attributeKey).toString();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority(user.getRole().toString()));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return "kakao";
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/boda_server/domain/auth/dto/OAuth2Response.java
+++ b/src/main/java/com/example/boda_server/domain/auth/dto/OAuth2Response.java
@@ -1,0 +1,51 @@
+package com.example.boda_server.domain.auth.dto;
+
+import com.example.boda_server.domain.user.entity.Role;
+import com.example.boda_server.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Builder
+@Getter
+public class OAuth2Response {
+    private String name;
+    private String email;
+    private String profileUrl;
+
+    public OAuth2Response(String name, String email, String profileUrl) {
+        this.name = name;
+        this.email = email;
+        this.profileUrl = profileUrl;
+    }
+
+    public static OAuth2Response of(String registrationId, Map<String, Object> attributes) {
+        if (registrationId.equals("kakao")) {
+            return ofKakao(attributes);
+        } else {
+            //throw new AuthException(ILLEGAL_REGISTRATION_ID);
+            return null;
+        }
+    }
+
+    private static OAuth2Response ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        return OAuth2Response.builder()
+                .name((String) profile.get("nickname"))
+                .email((String) account.get("email"))
+                .profileUrl((String) profile.get("profile_image_url"))
+                .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .nickname(name)
+                .email(email)
+                .profileImageUrl(profileUrl)
+                .role(Role.USER)
+                .build();
+    }
+}

--- a/src/main/java/com/example/boda_server/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/boda_server/domain/auth/exception/AuthErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다.");
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
+    CANNOT_LOGOUT_OAUTH_SERVICE(HttpStatus.UNAUTHORIZED, "로그아웃을 진행할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/boda_server/domain/auth/handler/KakaoLogoutHandler.java
+++ b/src/main/java/com/example/boda_server/domain/auth/handler/KakaoLogoutHandler.java
@@ -1,0 +1,53 @@
+package com.example.boda_server.domain.auth.handler;
+
+
+import com.example.boda_server.domain.auth.exception.AuthErrorCode;
+import com.example.boda_server.global.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class KakaoLogoutHandler implements LogoutHandler{
+
+    @Value("${kakao.api.key}")
+    private String clientId;
+
+    @Value("${logoutRedirectUri}")
+    private String logoutRedirectUri;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        // 카카오 로그아웃 URL 생성
+        String kakaoLogoutUrl = String.format(
+                "https://kauth.kakao.com/oauth/logout?client_id=%s&logout_redirect_uri=%s",
+                clientId, logoutRedirectUri);
+
+        // 세션 무효화
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+
+        // 시큐리티 컨텍스트 로그아웃 처리
+        SecurityContextLogoutHandler securityContextLogoutHandler = new SecurityContextLogoutHandler();
+        securityContextLogoutHandler.logout(request, response, authentication);
+
+        // 카카오 로그아웃 URL로 리다이렉트
+        try {
+            response.sendRedirect(kakaoLogoutUrl);
+        } catch (Exception e) {
+            throw new BusinessException(AuthErrorCode.CANNOT_LOGOUT_OAUTH_SERVICE);
+        }
+
+    }
+
+}
+

--- a/src/main/java/com/example/boda_server/domain/auth/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/example/boda_server/domain/auth/handler/OAuthLoginSuccessHandler.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -21,6 +22,9 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    @Value("${app.frontend.url}")
+    private String frontendUrl;
+
     private final UserRepository userRepository;
 
     @Override
@@ -31,15 +35,15 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         String email = (String) account.get("email");
 
         Map<String, Object> profile = (Map<String, Object>) account.get("profile");
-        String profileUrl = (String) profile.get("profile_url");
+        String profileImageUrl = (String) profile.get("profile_image_url");
 
         if (needsAdditionalInfo(email)) {
             HttpSession session = request.getSession();
             session.setAttribute(SessionConstants.OAUTH_EMAIL, email);
-            session.setAttribute(SessionConstants.OAUTH_PROFILE_URL, profileUrl);
-            getRedirectStrategy().sendRedirect(request, response, "/register");
+            session.setAttribute(SessionConstants.OAUTH_PROFILE_URL, profileImageUrl);
+            getRedirectStrategy().sendRedirect(request, response, frontendUrl+"/register");
         } else {
-            getRedirectStrategy().sendRedirect(request, response, "/");
+            getRedirectStrategy().sendRedirect(request, response, frontendUrl+"/");
         }
     }
 

--- a/src/main/java/com/example/boda_server/domain/auth/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/example/boda_server/domain/auth/handler/OAuthLoginSuccessHandler.java
@@ -8,7 +8,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -18,10 +18,10 @@ import java.io.IOException;
 import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -44,7 +44,7 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     }
 
         /**
-         * 사용자의 추가 정보가 필요한지 확인
+         * 사용자의 추가 정보가 필요한지 확인하는 로직
          */
         private boolean needsAdditionalInfo(String email) {
             User target = userRepository.findByEmail(email).orElse(null);

--- a/src/main/java/com/example/boda_server/domain/auth/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/example/boda_server/domain/auth/handler/OAuthLoginSuccessHandler.java
@@ -1,0 +1,56 @@
+package com.example.boda_server.domain.auth.handler;
+
+
+import com.example.boda_server.domain.user.entity.User;
+import com.example.boda_server.domain.user.repository.UserRepository;
+import com.example.boda_server.global.constant.SessionConstants;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> account = oAuth2User.getAttribute("kakao_account");
+        String email = (String) account.get("email");
+
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        String profileUrl = (String) profile.get("profile_url");
+
+        if (needsAdditionalInfo(email)) {
+            HttpSession session = request.getSession();
+            session.setAttribute(SessionConstants.OAUTH_EMAIL, email);
+            session.setAttribute(SessionConstants.OAUTH_PROFILE_URL, profileUrl);
+            getRedirectStrategy().sendRedirect(request, response, "/register");
+        } else {
+            getRedirectStrategy().sendRedirect(request, response, "/");
+        }
+    }
+
+        /**
+         * 사용자의 추가 정보가 필요한지 확인
+         */
+        private boolean needsAdditionalInfo(String email) {
+            User target = userRepository.findByEmail(email).orElse(null);
+            if (target == null){
+                return true;
+            }
+            return false;
+        }
+}

--- a/src/main/java/com/example/boda_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/boda_server/domain/auth/service/AuthService.java
@@ -1,0 +1,35 @@
+package com.example.boda_server.domain.auth.service;
+
+import com.example.boda_server.domain.user.dto.UserPartialDto;
+import com.example.boda_server.domain.user.entity.Role;
+import com.example.boda_server.domain.user.entity.User;
+import com.example.boda_server.domain.user.repository.UserRepository;
+import com.example.boda_server.global.constant.SessionConstants;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public User register(HttpServletRequest http, UserPartialDto userPartialDto){
+        HttpSession session = http.getSession();
+        String email = (String) session.getAttribute(SessionConstants.OAUTH_EMAIL);
+        String profileUrl = (String) session.getAttribute(SessionConstants.OAUTH_PROFILE_URL);
+
+        User user = User.builder()
+                .email(email)
+                .nickname(userPartialDto.getNickname())
+                .gender(userPartialDto.getGender())
+                .ageRange(userPartialDto.getAgeRange())
+                .role(Role.USER)
+                .profileImageUrl(profileUrl)
+                .build();
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/example/boda_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/boda_server/domain/auth/service/AuthService.java
@@ -1,35 +1,45 @@
 package com.example.boda_server.domain.auth.service;
 
-import com.example.boda_server.domain.user.dto.UserPartialDto;
+import com.example.boda_server.domain.user.dto.request.UserPartialRequest;
+import com.example.boda_server.domain.user.dto.response.UserResponse;
 import com.example.boda_server.domain.user.entity.Role;
 import com.example.boda_server.domain.user.entity.User;
 import com.example.boda_server.domain.user.repository.UserRepository;
 import com.example.boda_server.global.constant.SessionConstants;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class AuthService {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
-    public User register(HttpServletRequest http, UserPartialDto userPartialDto){
+    /**
+     * 소셜로그인에서 받아온 정보와 사용자가 추가 입력한 정보를 저장하는 로직
+     */
+    public UserResponse register(HttpServletRequest http, UserPartialRequest userPartialRequest){
         HttpSession session = http.getSession();
         String email = (String) session.getAttribute(SessionConstants.OAUTH_EMAIL);
         String profileUrl = (String) session.getAttribute(SessionConstants.OAUTH_PROFILE_URL);
 
         User user = User.builder()
                 .email(email)
-                .nickname(userPartialDto.getNickname())
-                .gender(userPartialDto.getGender())
-                .ageRange(userPartialDto.getAgeRange())
+                .nickname(userPartialRequest.getNickname())
+                .gender(userPartialRequest.getGender())
+                .ageRange(userPartialRequest.getAgeRange())
                 .role(Role.USER)
                 .profileImageUrl(profileUrl)
                 .build();
 
-        return userRepository.save(user);
+        User created = userRepository.save(user);
+
+        return UserResponse.builder()
+                .user(created)
+                .build();
     }
 }

--- a/src/main/java/com/example/boda_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/boda_server/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
     public UserResponse register(HttpServletRequest http, UserPartialRequest userPartialRequest){
         HttpSession session = http.getSession();
         String email = (String) session.getAttribute(SessionConstants.OAUTH_EMAIL);
-        String profileUrl = (String) session.getAttribute(SessionConstants.OAUTH_PROFILE_URL);
+        String profileImageUrl = (String) session.getAttribute(SessionConstants.OAUTH_PROFILE_URL);
 
         User user = User.builder()
                 .email(email)
@@ -33,7 +33,7 @@ public class AuthService {
                 .gender(userPartialRequest.getGender())
                 .ageRange(userPartialRequest.getAgeRange())
                 .role(Role.USER)
-                .profileImageUrl(profileUrl)
+                .profileImageUrl(profileImageUrl)
                 .build();
 
         User created = userRepository.save(user);

--- a/src/main/java/com/example/boda_server/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/boda_server/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,53 @@
+package com.example.boda_server.domain.auth.service;
+
+
+import com.example.boda_server.domain.auth.dto.CustomOAuth2User;
+import com.example.boda_server.domain.auth.dto.OAuth2Response;
+import com.example.boda_server.domain.user.entity.User;
+import com.example.boda_server.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. 유저 정보(attributes) 가져오기
+        Map<String, Object> oAuth2UserAttributes = super.loadUser(userRequest).getAttributes();
+
+        // 2. resistrationId 가져오기 (third-party id)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // 3. userNameAttributeName 가져오기
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        // 4. 유저 정보 dto 생성
+        OAuth2Response oAuth2Response = OAuth2Response.of(registrationId, oAuth2UserAttributes);
+
+        // 5. 회원가입 및 로그인
+        User user = getOrSave(oAuth2Response);
+
+        // 6. OAuth2User로 반환
+        return new CustomOAuth2User(user, oAuth2UserAttributes, userNameAttributeName);
+    }
+
+    private User getOrSave(OAuth2Response oAuth2Response) {
+        User user = userRepository.findByEmail(oAuth2Response.getEmail())
+                .orElseGet(oAuth2Response::toEntity);
+        return userRepository.save(user);
+    }
+
+}

--- a/src/main/java/com/example/boda_server/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/boda_server/domain/auth/service/CustomOAuth2UserService.java
@@ -4,7 +4,6 @@ package com.example.boda_server.domain.auth.service;
 import com.example.boda_server.domain.auth.dto.CustomOAuth2User;
 import com.example.boda_server.domain.auth.dto.OAuth2Response;
 import com.example.boda_server.domain.user.entity.User;
-import com.example.boda_server.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -18,8 +17,6 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
-
-    private final UserRepository userRepository;
 
     @Transactional
     @Override
@@ -37,7 +34,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // 4. 유저 정보 dto 생성
         OAuth2Response oAuth2Response = OAuth2Response.of(registrationId, oAuth2UserAttributes);
 
-        // 5. 회원가입 및 로그인
+        // 5. 로그인을 통해 얻는 정보 엔티티로 변환
         User user = getOrSave(oAuth2Response);
 
         // 6. OAuth2User로 반환
@@ -45,9 +42,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private User getOrSave(OAuth2Response oAuth2Response) {
-        User user = userRepository.findByEmail(oAuth2Response.getEmail())
-                .orElseGet(oAuth2Response::toEntity);
-        return userRepository.save(user);
+        User user = oAuth2Response.toEntity();
+        return user;
     }
 
 }

--- a/src/main/java/com/example/boda_server/domain/user/dto/UserPartialDto.java
+++ b/src/main/java/com/example/boda_server/domain/user/dto/UserPartialDto.java
@@ -1,0 +1,18 @@
+package com.example.boda_server.domain.user.dto;
+
+import com.example.boda_server.domain.user.entity.AgeRange;
+import com.example.boda_server.domain.user.entity.Gender;
+import lombok.Data;
+import lombok.Getter;
+
+/**
+ * 회원가입시 추가정보 입력
+ */
+@Data
+@Getter
+public class UserPartialDto {
+    // 닉네임, 성별, 연령대, //역할
+    private String nickname;
+    private Gender gender;
+    private AgeRange ageRange;
+}

--- a/src/main/java/com/example/boda_server/domain/user/dto/request/UserPartialRequest.java
+++ b/src/main/java/com/example/boda_server/domain/user/dto/request/UserPartialRequest.java
@@ -1,4 +1,4 @@
-package com.example.boda_server.domain.user.dto;
+package com.example.boda_server.domain.user.dto.request;
 
 import com.example.boda_server.domain.user.entity.AgeRange;
 import com.example.boda_server.domain.user.entity.Gender;
@@ -10,8 +10,8 @@ import lombok.Getter;
  */
 @Data
 @Getter
-public class UserPartialDto {
-    // 닉네임, 성별, 연령대, //역할
+public class UserPartialRequest {
+
     private String nickname;
     private Gender gender;
     private AgeRange ageRange;

--- a/src/main/java/com/example/boda_server/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/boda_server/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,39 @@
+package com.example.boda_server.domain.user.dto.response;
+
+import com.example.boda_server.domain.bookmark.entity.BookmarkFolder;
+import com.example.boda_server.domain.recommendation.entity.TourInformation;
+import com.example.boda_server.domain.user.entity.AgeRange;
+import com.example.boda_server.domain.user.entity.Gender;
+import com.example.boda_server.domain.user.entity.Role;
+import com.example.boda_server.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Getter
+public class UserResponse {
+    private String nickname;
+    private String email;
+    private String profileImageUrl;
+    private AgeRange ageRange;
+    private Gender gender;
+    private Role role;
+    private List<TourInformation> tourInformations;
+    private List<BookmarkFolder> bookmarkFolders;
+
+    @Builder
+    public  UserResponse(User user){
+        this.nickname = user.getNickname();
+        this.email = user.getEmail();
+        this.profileImageUrl = user.getProfileImageUrl();
+        this.ageRange = user.getAgeRange();
+        this.gender = user.getGender();
+        this.role = user.getRole();
+        this.tourInformations = user.getTourInformations() != null ? user.getTourInformations() : new ArrayList<>();
+        this.bookmarkFolders = user.getBookmarkFolders() != null ? user.getBookmarkFolders() : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/example/boda_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/boda_server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.boda_server.global.config;
 
+import com.example.boda_server.domain.auth.handler.OAuthLoginSuccessHandler;
 import com.example.boda_server.domain.auth.service.CustomOAuth2UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +15,8 @@ public class SecurityConfig {
 
     @Autowired
     private CustomOAuth2UserService customOAuth2UserService;
+    @Autowired
+    private OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,7 +29,8 @@ public class SecurityConfig {
         http
                 .oauth2Login((oauth2) -> oauth2
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)));
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuthLoginSuccessHandler));
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()

--- a/src/main/java/com/example/boda_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/boda_server/global/config/SecurityConfig.java
@@ -1,8 +1,9 @@
 package com.example.boda_server.global.config;
 
+import com.example.boda_server.domain.auth.handler.KakaoLogoutHandler;
 import com.example.boda_server.domain.auth.handler.OAuthLoginSuccessHandler;
 import com.example.boda_server.domain.auth.service.CustomOAuth2UserService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,12 +12,12 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Autowired
-    private CustomOAuth2UserService customOAuth2UserService;
-    @Autowired
-    private OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+    private final KakaoLogoutHandler kakaoLogoutHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -36,6 +37,15 @@ public class SecurityConfig {
                         .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
                         .anyRequest().authenticated()
                 );
+
+        http
+                .logout((logout) -> logout
+                        .logoutSuccessUrl("/")
+                        .clearAuthentication(true)
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID")
+                        .addLogoutHandler(kakaoLogoutHandler)
+                        .permitAll());
 
         return http.build();
     }

--- a/src/main/java/com/example/boda_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/boda_server/global/config/SecurityConfig.java
@@ -1,7 +1,38 @@
 package com.example.boda_server.global.config;
 
+import com.example.boda_server.domain.auth.service.CustomOAuth2UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    @Autowired
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf((csrf) -> csrf.disable());
+        http
+                .formLogin((login) -> login.disable());
+        http
+                .httpBasic((basic) -> basic.disable());
+        http
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService)));
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/example/boda_server/global/config/WebConfig.java
+++ b/src/main/java/com/example/boda_server/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.example.boda_server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000", "https://accounts.kakao.com")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+
+}

--- a/src/main/java/com/example/boda_server/global/config/WebConfig.java
+++ b/src/main/java/com/example/boda_server/global/config/WebConfig.java
@@ -16,4 +16,5 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true);
     }
 
+
 }

--- a/src/main/java/com/example/boda_server/global/constant/SessionConstants.java
+++ b/src/main/java/com/example/boda_server/global/constant/SessionConstants.java
@@ -1,0 +1,9 @@
+package com.example.boda_server.global.constant;
+
+/**
+ * 세션 키 모음
+ */
+public class SessionConstants {
+    public static final String OAUTH_EMAIL = "OAUTH_EMAIL";
+    public static final String OAUTH_PROFILE_URL = "OAUTH_PROFILE_URL";
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #BODA-14
<br/>

## 📝 작업 내용

> 카카오 소셜 로그인을 통해서 로그인을 진행하고, 해당 회원이 DB에 있다면 로그인을 완료하고 해당 회원이 DB에 없으면 그때 얻은 email정보와 profileImageUrl정보를 세션에 넣고 추가 정보 페이지로 리다이렉트 해준다. 추가 정보 페이지에서 성별, 사용자의 추가 정보를 얻어서 세션에 있는 사용자 정보와 함께 db에 저장하도록 하였습니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 세션에 넣은 정보와 입력 받은 정보가 잘 들어가는지 테스트가 필요합니다.
